### PR TITLE
Incorporate minibatch-training 

### DIFF
--- a/deepvelo/train.py
+++ b/deepvelo/train.py
@@ -86,7 +86,7 @@ def train(
     callback: Callable = None,
     **kwargs,
 ):
-    batch_size, n_genes = adata.layers["Ms"].shape
+    batch_size, n_genes = adata.layers["Ms"].shape # To be changed after mini-batch training is implemented
     if configs["data_loader"]["args"]["velocity_genes"]:
         n_genes = int(np.sum(adata.var["velocity_genes"]))
     configs["arch"]["args"]["n_genes"] = n_genes


### PR DESCRIPTION
Currently, minibatch training is not incorporated because of limitations in the graph-base training setup.

Aim of PR is to:

- Enable minibatch training in the model
- Test stability of minibatch training, especially with current hyperparameter setup of the model
- After stability ensured, incorporate explicit parallelization (DataParallel already available in BaseTrainer, but DDP not implemented) for multi-gpu training